### PR TITLE
Remove overscroll-behavior-y: none to restore scroll bounce

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -119,7 +119,6 @@
   html, body {
     @apply bg-background text-foreground;
     overflow-x: hidden;
-    overscroll-behavior-y: none;
   }
 }
 


### PR DESCRIPTION
Enables the native iOS scroll bounce/rubber-banding effect.