### PR TITLE
fix: feature Freighter in WalletConnect modal via appKitOptions

### DIFF
--- a/hooks/use-stellar-wallet-kit.ts
+++ b/hooks/use-stellar-wallet-kit.ts
@@ -82,6 +82,15 @@ async function ensureInitialized(network: Networks): Promise<void> {
           allowedChains: network === Networks.PUBLIC
             ? [WalletConnectTargetChain.PUBLIC]
             : [WalletConnectTargetChain.TESTNET],
+          // Kit's default Freighter id is stale in the live Reown Explorer; override here.
+          // Cast is needed because appKitOptions is typed as the full CreateAppKit shape,
+          // but the kit spreads it over its own projectId/networks at runtime.
+          appKitOptions: {
+            featuredWalletIds: [
+              "997a355c8f682468706a76cff1b004a7115f505fb962dac54b6e9b442dd1c380", // Freighter
+              "76a3d548a08cf402f5c7d021f24fd2881d767084b387a5325df88bc3d4b6f21b", // Lobstr
+            ],
+          } as unknown as ConstructorParameters<typeof WalletConnectModule>[0]["appKitOptions"],
         })
         modules.push(walletConnectModule)
       }


### PR DESCRIPTION
## Summary

Freighter is silently absent from the featured row of Smoothie's WalletConnect modal. The `@creit-tech/stellar-wallets-kit` ships a default `featuredWalletIds` array that hardcodes a Freighter id (`aef3112a…`) which no longer exists in the live WalletConnect Cloud Explorer — and the Explorer is what Reown AppKit resolves `featuredWalletIds` against at runtime. Net effect: only Lobstr shows up in the featured row today.

This PR overrides the kit's default list via `appKitOptions.featuredWalletIds` in `hooks/use-stellar-wallet-kit.ts`, passing the canonical id the Explorer currently returns for Freighter. Lobstr's id is included too because the override fully replaces (not merges with) the kit's default array.

## Evidence

Same endpoint Reown AppKit hits internally:

```
https://explorer-api.walletconnect.com/v3/wallets?projectId=<any>&search=freighter
```

Returns exactly one Freighter entry:

- **id:** `997a355c8f682468706a76cff1b004a7115f505fb962dac54b6e9b442dd1c380`
- **name:** Freighter
- **homepage:** https://www.freighter.app/
- **platforms:** iOS + Android

Reverse lookup confirms the stale id is gone:

```
https://explorer-api.walletconnect.com/v3/wallets?projectId=<any>&ids=aef3112adf415ec870529e96b4d7b434f13961a079d1ee42c9738217d8adeb91,997a355c8f682468706a76cff1b004a7115f505fb962dac54b6e9b442dd1c380
```

Only `997a355c…` comes back.

## Upstream fix

An upstream fix has also been opened against the kit itself: [Creit-Tech/Stellar-Wallets-Kit#89](https://github.com/Creit-Tech/Stellar-Wallets-Kit/pull/89). Once that PR is merged and the kit publishes a new release, the override in this PR becomes redundant — Smoothie can safely remove the `appKitOptions` block after bumping the dependency. Until then, this local override is the only way for Smoothie to feature Freighter in the modal.

## Test plan

- [ ] `npm install && npm run dev`
- [ ] Open the app, click Connect Wallet → the WalletConnect entry
- [ ] In the Reown AppKit modal, confirm **Freighter** appears in the featured row at the top (alongside Lobstr)
- [ ] Repeat on `NEXT_PUBLIC_STELLAR_NETWORK=public` and on testnet — same behavior expected in both
- [ ] `npm run lint` passes (verified locally)
- [ ] `npx tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)